### PR TITLE
Enable GeoAware year timestamp

### DIFF
--- a/app/Http/ViewComposers/LayoutComposer.php
+++ b/app/Http/ViewComposers/LayoutComposer.php
@@ -7,7 +7,7 @@ class LayoutComposer
 {
     public function compose(View $view)
     {
-        $copyRighter = CopyrighterFactory::create();
+        $copyRighter = CopyrighterFactory::create(['geo-locator' => 'FreeGeoIP']);
         $view->with('copyright', $copyRighter->getCopyright());
     }
 }


### PR DESCRIPTION
A `composer update` will have to be run to update to the latest patch version, `Copyrighter 1.0.2`
